### PR TITLE
Add Pathlib Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Data types need to serializable for the selected file format
 - `datetime.time`
 - `datetime.timedelta`
 - `enum.Enum`
+- `pathlib.Path`
 
 By default, when any attribute is accessed, the configured file will be read.
 If the file does not exist, the default value will be used.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
     name = "simple-file-settings"
-    version = "0.1.4"
+    version = "0.1.5"
     description = "Easily load and save simple configuration data to and from disk through a type-checked data class."
     readme = "README.md"
     authors = [{ name = "Nathan Vaughn", email = "nath@nvaughn.email" }]
@@ -17,6 +17,9 @@
     requires-python = ">=3.9"
     dependencies = ["typeguard>=4.2.1"]
 
+[dependency-groups]
+    dev = ["pre-commit>=3.2.0", "pytest>=8.3.3", "pytest-cov>=5.0.0"]
+
 [project.optional-dependencies]
     yaml  = ["pyyaml>=6.0.1"]
     json5 = ["pyjson5>=1.6.6"]
@@ -28,11 +31,6 @@
     Issues     = "https://github.com/NathanVaughn/simple-file-settings/issues"
 
 [tool.uv]
-    dev-dependencies = [
-        "pre-commit>=3.2.0",
-        "pytest>=8.3.3",
-        "pytest-cov>=5.0.0",
-    ]
     package = true
 
 [tool.coverage.run]

--- a/simplefilesettings/_base.py
+++ b/simplefilesettings/_base.py
@@ -91,17 +91,17 @@ class BaseClass(abc.ABC):
 
         # if the requested key is in the config, return it
         if key in self.__data:
-            # deserialize the value
-            value = simplefilesettings.serializer.deserialize(
-                self.__data[key], type_hint=type_hint
-            )
+            with contextlib.suppress(typeguard.TypeCheckError, ValueError):
+                # deserialize the value
+                value = simplefilesettings.serializer.deserialize(
+                    self.__data[key], type_hint=type_hint
+                )
 
-            with contextlib.suppress(typeguard.TypeCheckError):
                 # make sure the value is of the correct type
-                # otherwise, return the default
                 typeguard.check_type(value, type_hint)
                 return value
 
+        # otherwise, return the default
         # if we have a set default value that is not None, write it out
         if default is not None:
             self.__set(key, default)
@@ -127,7 +127,9 @@ class BaseClass(abc.ABC):
 
         # declared field
         return self.__get(
-            name, self.__field_type_hints[name], self.__field_defaults[name]
+            key=name,
+            type_hint=self.__field_type_hints[name],
+            default=self.__field_defaults[name],
         )
 
     def __setattr__(self, name: str, value: typing.Any) -> None:

--- a/simplefilesettings/serializer.py
+++ b/simplefilesettings/serializer.py
@@ -1,8 +1,12 @@
 import datetime
 import enum
+import pathlib
 import typing
 
 T = typing.TypeVar("T", bound=enum.Enum)
+
+
+# region: enum
 
 
 def _serialize_enum(obj: enum.Enum) -> str:
@@ -11,6 +15,10 @@ def _serialize_enum(obj: enum.Enum) -> str:
 
 def _deserialize_enum(value: typing.Union[int, str], obj: typing.Type[T]) -> T:
     return obj(value)
+
+
+# endregion
+# region: datetime
 
 
 def _serialize_datetime(dt: datetime.datetime) -> str:
@@ -45,6 +53,21 @@ def _deserialize_time(value: str) -> datetime.time:
     return datetime.time.fromisoformat(value)
 
 
+# endregion
+# region: pathlib
+
+
+def _serialize_pathlib(obj: pathlib.Path) -> str:
+    return str(obj)
+
+
+def _deserialize_pathlib(value: str) -> pathlib.Path:
+    return pathlib.Path(value)
+
+
+# endregion
+
+
 def serialize(value: typing.Any) -> typing.Any:
     if isinstance(value, enum.Enum):
         return _serialize_enum(value)
@@ -56,6 +79,8 @@ def serialize(value: typing.Any) -> typing.Any:
         return _serialize_date(value)
     elif isinstance(value, datetime.time):
         return _serialize_time(value)
+    elif isinstance(value, pathlib.Path):
+        return _serialize_pathlib(value)
     return value
 
 
@@ -70,4 +95,6 @@ def deserialize(value: typing.Any, type_hint: typing.Any) -> typing.Any:
         return _deserialize_date(value)
     elif type_hint == datetime.time:
         return _deserialize_time(value)
+    elif type_hint == pathlib.Path:
+        return _deserialize_pathlib(value)
     return value

--- a/tests/test__base.py
+++ b/tests/test__base.py
@@ -120,6 +120,44 @@ def test_handle_invalid_field_type_file(temp_file: str) -> None:
 
 
 @pytest.mark.parametrize("temp_file", [("valid.json")], indirect=["temp_file"])
+def test_invalid_enum_file(temp_file: str) -> None:
+    """
+    Ensure that files with invalid enum values are ignored.
+    """
+
+    class TestEnum(enum.Enum):
+        A = "A"
+        B = "B"
+
+    class TestClass(JSONClass):
+        key1: TestEnum = TestEnum.B
+
+        class Config:
+            json_file = temp_file
+
+    # make sure the default value is used
+    tc = TestClass()
+    assert tc.key1 == TestEnum.B
+
+
+@pytest.mark.parametrize("temp_file", [("valid.json")], indirect=["temp_file"])
+def test_invalid_datetime_file(temp_file: str) -> None:
+    """
+    Ensure that files with invalid datetime values are ignored.
+    """
+
+    class TestClass(JSONClass):
+        key1: datetime.datetime = datetime.datetime(2021, 1, 1, 0, 0, 0)
+
+        class Config:
+            json_file = temp_file
+
+    # make sure the default value is used
+    tc = TestClass()
+    assert tc.key1 == datetime.datetime(2021, 1, 1, 0, 0, 0)
+
+
+@pytest.mark.parametrize("temp_file", [("valid.json")], indirect=["temp_file"])
 def test_valid_file(temp_file: str) -> None:
     """
     Ensure normal behavior works.

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,5 +1,6 @@
 import datetime
 import enum
+import pathlib
 import sys
 import typing
 
@@ -67,6 +68,12 @@ def test_time() -> None:
     assert simplefilesettings.serializer._deserialize_time(t.isoformat()) == t
 
 
+def test_pathlib() -> None:
+    p = pathlib.Path(__file__)
+    assert simplefilesettings.serializer._serialize_pathlib(p) == str(p)
+    assert simplefilesettings.serializer._deserialize_pathlib(str(p)) == p
+
+
 @pytest.mark.parametrize(
     "given, expected",
     (
@@ -77,6 +84,7 @@ def test_time() -> None:
         (datetime.timedelta(days=1, hours=2, minutes=3, seconds=4), 93784.0),
         (datetime.datetime(2021, 1, 1).date(), "2021-01-01"),
         (datetime.datetime(2021, 1, 1).time(), "00:00:00"),
+        (pathlib.Path(__file__), str(pathlib.Path(__file__))),
     ),
 )
 def test_serializer(given: typing.Any, expected: typing.Any) -> None:
@@ -101,6 +109,7 @@ def test_serializer(given: typing.Any, expected: typing.Any) -> None:
         ),
         ("2021-01-01", datetime.date, datetime.datetime(2021, 1, 1).date()),
         ("00:00:00", datetime.time, datetime.datetime(2021, 1, 1).time()),
+        (str(pathlib.Path(__file__)), pathlib.Path, pathlib.Path(__file__)),
     ),
 )
 def test_deserializer(

--- a/uv.lock
+++ b/uv.lock
@@ -380,7 +380,7 @@ wheels = [
 
 [[package]]
 name = "simple-file-settings"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "typeguard" },
@@ -398,7 +398,7 @@ yaml = [
     { name = "pyyaml" },
 ]
 
-[package.dev-dependencies]
+[package.dependency-groups]
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
@@ -414,7 +414,7 @@ requires-dist = [
     { name = "typeguard", specifier = ">=4.2.1" },
 ]
 
-[package.metadata.requires-dev]
+[package.metadata.dependency-groups]
 dev = [
     { name = "pre-commit", specifier = ">=3.2.0" },
     { name = "pytest", specifier = ">=8.3.3" },


### PR DESCRIPTION
- Add `pathlib.path` to supported objects
- Fix exception that could occur if a `datetime` or `enum` object failed to parse

## Summary by Sourcery

Add support for pathlib.Path serialization and deserialization, fix exception handling for datetime and enum parsing errors, and update documentation and tests accordingly.

New Features:
- Add support for serializing and deserializing pathlib.Path objects.

Bug Fixes:
- Fix exception handling for failed parsing of datetime and enum objects.

Documentation:
- Update README to include pathlib.Path as a supported data type.

Tests:
- Add tests for pathlib.Path serialization and deserialization.
- Add tests to ensure files with invalid enum and datetime values are ignored.