### PR TITLE
Fix issue with typing.Literal type hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
     name = "simple-file-settings"
-    version = "0.1.5"
+    version = "0.1.6"
     description = "Easily load and save simple configuration data to and from disk through a type-checked data class."
     readme = "README.md"
     authors = [{ name = "Nathan Vaughn", email = "nath@nvaughn.email" }]

--- a/simplefilesettings/serializer.py
+++ b/simplefilesettings/serializer.py
@@ -2,6 +2,7 @@ import datetime
 import enum
 import pathlib
 import typing
+import inspect
 
 T = typing.TypeVar("T", bound=enum.Enum)
 
@@ -85,7 +86,9 @@ def serialize(value: typing.Any) -> typing.Any:
 
 
 def deserialize(value: typing.Any, type_hint: typing.Any) -> typing.Any:
-    if issubclass(type_hint, enum.Enum):
+    # https://stackoverflow.com/a/395782/9944427
+    # Fixes bug where typing.Literal as a type hint would error
+    if inspect.isclass(type_hint) and issubclass(type_hint, enum.Enum):
         return _deserialize_enum(value, type_hint)
     elif type_hint == datetime.datetime:
         return _deserialize_datetime(value)

--- a/tests/test__base.py
+++ b/tests/test__base.py
@@ -290,6 +290,7 @@ def test_valid_file_2(temp_file: str) -> None:
     assert tc.key1 == TestEnum.A
     assert tc.key2 == datetime.datetime(2024, 2, 3, 5, 3, 0)
 
+
 @pytest.mark.parametrize("temp_file", [("valid.json")], indirect=["temp_file"])
 def test_valid_file_3(temp_file: str) -> None:
     """

--- a/tests/test__base.py
+++ b/tests/test__base.py
@@ -2,6 +2,7 @@ import datetime
 import enum
 import json
 
+import typing
 import pytest
 import typeguard
 
@@ -288,3 +289,19 @@ def test_valid_file_2(temp_file: str) -> None:
     tc = TestClass()
     assert tc.key1 == TestEnum.A
     assert tc.key2 == datetime.datetime(2024, 2, 3, 5, 3, 0)
+
+@pytest.mark.parametrize("temp_file", [("valid.json")], indirect=["temp_file"])
+def test_valid_file_3(temp_file: str) -> None:
+    """
+    Ensure normal behavior works with Literal type hint
+    """
+
+    class TestClass(JSONClass):
+        key1: str = "value1"
+        key2: typing.Literal["value1", "value2"] = "value1"
+
+        class Config:
+            json_file = temp_file
+
+    tc = TestClass()
+    assert tc.key2 == "value2"

--- a/uv.lock
+++ b/uv.lock
@@ -380,7 +380,7 @@ wheels = [
 
 [[package]]
 name = "simple-file-settings"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "typeguard" },
@@ -398,7 +398,7 @@ yaml = [
     { name = "pyyaml" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
@@ -414,7 +414,7 @@ requires-dist = [
     { name = "typeguard", specifier = ">=4.2.1" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=3.2.0" },
     { name = "pytest", specifier = ">=8.3.3" },


### PR DESCRIPTION
Add a check for `inspect.isclass` first. Otherwise `issubclass` complains that `typing.Literal` is not a class.